### PR TITLE
Please moderate user comment (Staticman)

### DIFF
--- a/_data/comments/how-classical-planets-rule-zodiac/entry1550792226284.yml
+++ b/_data/comments/how-classical-planets-rule-zodiac/entry1550792226284.yml
@@ -1,0 +1,15 @@
+_id: 990686f0-3631-11e9-a611-ad9a3a66cc80
+_parent: /posts/astrology/philosophy/2018/10/05/how-classical-planets-rule-zodiac.html
+message: >-
+  The table at the end makes me confused because in traditional astrology, from
+  what I've read, it depends on the planetary sect. I read "A Practical Guide to
+  Traditional Astrology" by Robert Crane and he said that diurnal planets tend
+  to 'prefer' their diurnal signs (So, Jupiter prefers Sagittarius, Saturn
+  prefers Capricorn) and that nocturnal planets 'prefer' nocturnal signs (Mars
+  for Scorpio, Venus for Taurus). Why did you [or others] discard this idea?
+name: Confused
+email: 45710c2243c8177ca3ffec9671a8c025
+url: ''
+replying_to: ''
+hidden: ''
+date: 1550792226


### PR DESCRIPTION
Accept or discard comment from Time Nomad website.

---
| Field       | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| message     | The table at the end makes me confused because in traditional astrology, from what I've read, it depends on the planetary sect. I read "A Practical Guide to Traditional Astrology" by Robert Crane and he said that diurnal planets tend to 'prefer' their diurnal signs (So, Jupiter prefers Sagittarius, Saturn prefers Capricorn) and that nocturnal planets 'prefer' nocturnal signs (Mars for Scorpio, Venus for Taurus). Why did you [or others] discard this idea? |
| name        | Confused                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
| email       | 45710c2243c8177ca3ffec9671a8c025                                                                                                                                                                                                                                                                                                                                                                                                                                           |
| url         |                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
| replying_to |                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
| hidden      |                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
| date        | 1550792226                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |

<!--staticman_notification:{"configPath":{"file":"staticman.yml","path":"comments"},"fields":{"message":"The table at the end makes me confused because in traditional astrology, from what I've read, it depends on the planetary sect. I read \"A Practical Guide to Traditional Astrology\" by Robert Crane and he said that diurnal planets tend to 'prefer' their diurnal signs (So, Jupiter prefers Sagittarius, Saturn prefers Capricorn) and that nocturnal planets 'prefer' nocturnal signs (Mars for Scorpio, Venus for Taurus). Why did you [or others] discard this idea?","name":"Confused","email":"45710c2243c8177ca3ffec9671a8c025","url":"","replying_to":"","hidden":"","date":1550792226},"options":{"origin":"https://timenomad.app/posts/astrology/philosophy/2018/10/05/how-classical-planets-rule-zodiac.html","parent":"/posts/astrology/philosophy/2018/10/05/how-classical-planets-rule-zodiac.html","slug":"how-classical-planets-rule-zodiac","reCaptcha":{"siteKey":"","secret":""}},"parameters":{"version":"2","username":"astrotime","repository":"timenomad_app","branch":"master","property":"comments"}}-->