### PR TITLE
Please moderate user comment (Staticman)

### DIFF
--- a/_data/comments/sidereal-zodiac-in-astrology-its-strengths-and-weaknesses/entry1553900831906.yml
+++ b/_data/comments/sidereal-zodiac-in-astrology-its-strengths-and-weaknesses/entry1553900831906.yml
@@ -1,0 +1,14 @@
+_id: 6275e470-5277-11e9-b416-1b8d258a8fed
+_parent: >-
+  /posts/astrology/philosophy/2019/03/23/sidereal-zodiac-in-astrology-its-strengths-and-weaknesses.html
+message: >-
+  Good point, thank you for the explanation. To sum it up: the vernal Equinox
+  day was decided by the star rising above the horizon just before the sunrise
+  thus allowing for visual observation of the morning of the day of the vernal
+  Equinox — albeit introducing the shift of the Zodiac sign boundaries.
+name: Time Nomad
+email: 7d889e62c2c83b88ee77a003fc071935
+url: ''
+replying_to: '1'
+hidden: ''
+date: 1553900831


### PR DESCRIPTION
Accept or discard comment from Time Nomad website.

---
| Field       | Content                                                                                                                                                                                                                                                                                                     |
| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| message     | Good point, thank you for the explanation. To sum it up: the vernal Equinox day was decided by the star rising above the horizon just before the sunrise thus allowing for visual observation of the morning of the day of the vernal Equinox — albeit introducing the shift of the Zodiac sign boundaries. |
| name        | Time Nomad                                                                                                                                                                                                                                                                                                  |
| email       | 7d889e62c2c83b88ee77a003fc071935                                                                                                                                                                                                                                                                            |
| url         |                                                                                                                                                                                                                                                                                                             |
| replying_to | 1                                                                                                                                                                                                                                                                                                           |
| hidden      |                                                                                                                                                                                                                                                                                                             |
| date        | 1553900831                                                                                                                                                                                                                                                                                                  |

<!--staticman_notification:{"configPath":{"file":"staticman.yml","path":"comments"},"fields":{"message":"Good point, thank you for the explanation. To sum it up: the vernal Equinox day was decided by the star rising above the horizon just before the sunrise thus allowing for visual observation of the morning of the day of the vernal Equinox — albeit introducing the shift of the Zodiac sign boundaries.","name":"Time Nomad","email":"7d889e62c2c83b88ee77a003fc071935","url":"","replying_to":"1","hidden":"","date":1553900831},"options":{"origin":"https://timenomad.app/posts/astrology/philosophy/2019/03/23/sidereal-zodiac-in-astrology-its-strengths-and-weaknesses.html","parent":"/posts/astrology/philosophy/2019/03/23/sidereal-zodiac-in-astrology-its-strengths-and-weaknesses.html","slug":"sidereal-zodiac-in-astrology-its-strengths-and-weaknesses","reCaptcha":{"siteKey":"","secret":""}},"parameters":{"version":"2","username":"astrotime","repository":"timenomad_app","branch":"master","property":"comments"}}-->