### PR TITLE
Please moderate user comment (Staticman)

### DIFF
--- a/_data/comments/deep-astrology-vs-astrology-lite/entry1590225736227.yml
+++ b/_data/comments/deep-astrology-vs-astrology-lite/entry1590225736227.yml
@@ -1,0 +1,9 @@
+_id: e48865a0-9cd6-11ea-b41c-057372ec0a6e
+_parent: /posts/astrology/opinion/2020/05/17/deep-astrology-vs-astrology-lite.html
+message: "First Saturn–Pluto of 2053 will happen on 15 June at 20º Aquarius (sidereal), or 15º Pisces (tropical). The second will follow shortly on 10 July, and the third will be on 2 February, 2054 at 19º of the same sign.\r\n\r\n![Chart of Saturn–Pluto conjunction of 2053](/images/charts/time-nomad-saturn-pluto-2053-01.jpg)"
+name: Time Nomad
+email: 7d889e62c2c83b88ee77a003fc071935
+url: ''
+replying_to: '2'
+hidden: ''
+date: 1590225736


### PR DESCRIPTION
Accept or discard comment from Time Nomad website.

---
| Field       | Content                                                                                                                                                                                                                                                                                                                   |
| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| message     | First Saturn–Pluto of 2053 will happen on 15 June at 20º Aquarius (sidereal), or 15º Pisces (tropical). The second will follow shortly on 10 July, and the third will be on 2 February, 2054 at 19º of the same sign.

![Chart of Saturn–Pluto conjunction of 2053](/images/charts/time-nomad-saturn-pluto-2053-01.jpg) |
| name        | Time Nomad                                                                                                                                                                                                                                                                                                                |
| email       | 7d889e62c2c83b88ee77a003fc071935                                                                                                                                                                                                                                                                                          |
| url         |                                                                                                                                                                                                                                                                                                                           |
| replying_to | 2                                                                                                                                                                                                                                                                                                                         |
| hidden      |                                                                                                                                                                                                                                                                                                                           |
| date        | 1590225736                                                                                                                                                                                                                                                                                                                |

<!--staticman_notification:{"configPath":{"file":"staticman.yml","path":"comments"},"fields":{"message":"First Saturn–Pluto of 2053 will happen on 15 June at 20º Aquarius (sidereal), or 15º Pisces (tropical). The second will follow shortly on 10 July, and the third will be on 2 February, 2054 at 19º of the same sign.\r\n\r\n![Chart of Saturn–Pluto conjunction of 2053](/images/charts/time-nomad-saturn-pluto-2053-01.jpg)","name":"Time Nomad","email":"7d889e62c2c83b88ee77a003fc071935","url":"","replying_to":"2","hidden":"","date":1590225736},"options":{"origin":"https://timenomad.app/posts/astrology/opinion/2020/05/17/deep-astrology-vs-astrology-lite.html","parent":"/posts/astrology/opinion/2020/05/17/deep-astrology-vs-astrology-lite.html","slug":"deep-astrology-vs-astrology-lite","reCaptcha":{"siteKey":"","secret":""}},"parameters":{"version":"2","username":"astrotime","repository":"timenomad_app","branch":"master","property":"comments"}}-->