### PR TITLE
Please moderate user comment (Staticman)

### DIFF
--- a/_data/comments/planetary-hour-widget-and-alarm/entry1623169628030.yml
+++ b/_data/comments/planetary-hour-widget-and-alarm/entry1623169628030.yml
@@ -1,0 +1,13 @@
+_id: 5e29b5a0-c876-11eb-b5ec-6155b13c4ad4
+_parent: /documentation/planetary-hour-widget-and-alarm.html
+message: >-
+  Despite turning sound and voice on within the widget menu in the TN app, as
+  well as ensuring sound is enabled under the iPhone TN app notification
+  settings, I still hear no audio at the start of new planetary hours. Any
+  suggestions? I’d love to experience that feature! Thank you.
+name: K
+email: bd5bc6d10086660489cf512b44c3039c
+url: ''
+replying_to: ''
+hidden: ''
+date: 1623169628


### PR DESCRIPTION
Accept or discard comment from Time Nomad website.

---
| Field       | Content                                                                                                                                                                                                                                                                                  |
| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| message     | Despite turning sound and voice on within the widget menu in the TN app, as well as ensuring sound is enabled under the iPhone TN app notification settings, I still hear no audio at the start of new planetary hours. Any suggestions? I’d love to experience that feature! Thank you. |
| name        | K                                                                                                                                                                                                                                                                                        |
| email       | bd5bc6d10086660489cf512b44c3039c                                                                                                                                                                                                                                                         |
| url         |                                                                                                                                                                                                                                                                                          |
| replying_to |                                                                                                                                                                                                                                                                                          |
| hidden      |                                                                                                                                                                                                                                                                                          |
| date        | 1623169628                                                                                                                                                                                                                                                                               |

<!--staticman_notification:{"configPath":{"file":"staticman.yml","path":"comments"},"fields":{"message":"Despite turning sound and voice on within the widget menu in the TN app, as well as ensuring sound is enabled under the iPhone TN app notification settings, I still hear no audio at the start of new planetary hours. Any suggestions? I’d love to experience that feature! Thank you.","name":"K","email":"bd5bc6d10086660489cf512b44c3039c","url":"","replying_to":"","hidden":"","date":1623169628},"options":{"origin":"https://timenomad.app/documentation/planetary-hour-widget-and-alarm.html","parent":"/documentation/planetary-hour-widget-and-alarm.html","slug":"planetary-hour-widget-and-alarm","reCaptcha":{"siteKey":"","secret":""},"subscribe":"email"},"parameters":{"version":"2","username":"astrotime","repository":"timenomad_app","branch":"master","property":"comments"}}-->