### PR TITLE
Please moderate user comment (Staticman)

### DIFF
--- a/_data/comments/fixed-stars-in-astrological-chart/entry1712520062666.yml
+++ b/_data/comments/fixed-stars-in-astrological-chart/entry1712520062666.yml
@@ -1,0 +1,18 @@
+_id: 8f578850-f519-11ee-b63c-7b428c186244
+_parent: /documentation/fixed-stars-in-astrological-chart.html
+message: >-
+  I have a question about rising stars. What does it exactly mean when we say a
+  star is “rising”? I thought that rising meant closer to the ascendant (or over
+  the ascendant). For example, I have the star Regulus very close to the
+  ascendant degree. But I look at the “rise/set” tab report in the app add-on,
+  it only shows me the star Markeb as rising, which is in the same sign as the
+  ascendant, but very far from the ascendant degree, and under the horizon. Why
+  is it only Markeb considered rising, and not Regulus? The same goes for
+  another chart that I was looking at: Sirius is exactly on the ascendant
+  degree, but it only shows Pollux as a “rising” star. Thanks!
+name: Mara
+email: e23c46aa8e63ae8a3f7a6ee502e8e268
+url: ''
+replying_to: ''
+hidden: ''
+date: 1712520062


### PR DESCRIPTION
Accept or discard comment from Time Nomad website.

---
| Field       | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| message     | I have a question about rising stars. What does it exactly mean when we say a star is “rising”? I thought that rising meant closer to the ascendant (or over the ascendant). For example, I have the star Regulus very close to the ascendant degree. But I look at the “rise/set” tab report in the app add-on, it only shows me the star Markeb as rising, which is in the same sign as the ascendant, but very far from the ascendant degree, and under the horizon. Why is it only Markeb considered rising, and not Regulus? The same goes for another chart that I was looking at: Sirius is exactly on the ascendant degree, but it only shows Pollux as a “rising” star. Thanks! |
| name        | Mara                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
| email       | e23c46aa8e63ae8a3f7a6ee502e8e268                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
| url         |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
| replying_to |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
| hidden      |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
| date        | 1712520062                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |

<!--staticman_notification:{"configPath":{"file":"staticman.yml","path":"comments"},"fields":{"message":"I have a question about rising stars. What does it exactly mean when we say a star is “rising”? I thought that rising meant closer to the ascendant (or over the ascendant). For example, I have the star Regulus very close to the ascendant degree. But I look at the “rise/set” tab report in the app add-on, it only shows me the star Markeb as rising, which is in the same sign as the ascendant, but very far from the ascendant degree, and under the horizon. Why is it only Markeb considered rising, and not Regulus? The same goes for another chart that I was looking at: Sirius is exactly on the ascendant degree, but it only shows Pollux as a “rising” star. Thanks!","name":"Mara","email":"e23c46aa8e63ae8a3f7a6ee502e8e268","url":"","replying_to":"","hidden":"","date":1712520062},"options":{"origin":"https://timenomad.app/documentation/fixed-stars-in-astrological-chart.html","parent":"/documentation/fixed-stars-in-astrological-chart.html","slug":"fixed-stars-in-astrological-chart","reCaptcha":{"siteKey":"","secret":""},"subscribe":"email"},"parameters":{"version":"2","username":"astrotime","repository":"timenomad_app","branch":"master","property":"comments"}}-->